### PR TITLE
Use POST for voting

### DIFF
--- a/app/assets/javascripts/angular/factories/topic.coffee
+++ b/app/assets/javascripts/angular/factories/topic.coffee
@@ -1,9 +1,9 @@
 angular.module "lean-coffee"
   .factory "Topic", ($resource) ->
-    $resource("/topics/:id", 
-      { id: '@id', socket_id: -> window.pusherSocketId }, 
-      { 
+    $resource("/topics/:id",
+      { id: '@id', socket_id: -> window.pusherSocketId },
+      {
         update: { method: 'PUT' },
-        vote: { url: '/topics/:id/vote', method: 'PUT' }
-        remove_vote: { url: '/topics/:id/remove_vote', method: 'PUT' }
+        vote: { url: '/topics/:id/vote', method: 'POST' }
+        remove_vote: { url: '/topics/:id/remove_vote', method: 'POST' }
       })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   resources :topics
 
-  put 'topics/:id/vote' => 'topics#vote'
-  put 'topics/:id/remove_vote' => 'topics#remove_vote'
+  post 'topics/:id/vote' => 'topics#vote'
+  post 'topics/:id/remove_vote' => 'topics#remove_vote'
 
   root to: 'topics#index'
 end


### PR DESCRIPTION
From what I understand, PUT and PATCH should be used for idempotent
operations. If you send the same PUT request one time, it should be the
same as if you send it ten times.

For voting, that is not true! POST seems more appropriate.
