### PR TITLE
Fix API: Disable CSRF attacks protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 end


### PR DESCRIPTION
@jgorset, I've disabled forgery protection in order to make PUT/POST requests work correctly.
